### PR TITLE
QOS parameters via PVC annotations

### DIFF
--- a/docs/usage/simplyblock-csi/quality-of-service.md
+++ b/docs/usage/simplyblock-csi/quality-of-service.md
@@ -4,11 +4,16 @@ description: "Defining Quality of Service: Simplyblock's Kubernetes CSI driver s
 weight: 40600
 ---
 
-Simplyblock's CSI driver supports QoS limits on logical volumes. There are two ways to set them.
+Simplyblock's CSI driver supports QoS (Quality of Service) limits on logical volumes.
+
+To configure the QoS limits, simplyblock offers the following two options.
 
 ## Option 1: StorageClass
 
-QoS applies to all volumes using the StorageClass. Values are fixed at creation time.
+Using StorageClass instances, you can define QoS limits for all volumes sharing the same StorageClass. This enables
+the definition of paid performance classes for the user.
+
+With applying a StorageClass, the QoS limits are locked in at volume creation time.
 
 ```yaml title="StorageClass with QoS"
 apiVersion: storage.k8s.io/v1
@@ -27,7 +32,13 @@ volumeBindingMode: Immediate
 
 ## Option 2: PVC Annotations
 
-Use this for per-volume QoS without creating a dedicated StorageClass. Set annotations on the PVC before it is provisioned — values are locked in at volume creation time.
+If more control is required, simplyblock supports defining QoS limits on a per-PVC basis using Kubernetes PVC
+annotations.
+
+When using PVC annotations, no definition inside a StorageClass is required. If both are defined, PVC annotations take
+precedence.
+
+Like with StorageClass definitions, the QoS limits are locked in at volume creation time.
 
 ```yaml title="PVC with QoS annotations"
 kind: PersistentVolumeClaim
@@ -52,12 +63,13 @@ spec:
 
 All parameters are optional. Default is `0` (no limit).
 
-| Parameter / Annotation          | Description                          |
-|---------------------------------|--------------------------------------|
-| `qos_rw_iops` / `simplybk/qos-rw-iops`       | Max read+write IOPS      |
-| `qos_rw_mbytes` / `simplybk/qos-rw-mbytes`   | Max read+write throughput (MB/s) |
-| `qos_r_mbytes` / `simplybk/qos-r-mbytes`     | Max read throughput (MB/s)  |
-| `qos_w_mbytes` / `simplybk/qos-w-mbytes`     | Max write throughput (MB/s) |
+| StorageClass Parameter | Annotation               | Description                      |
+|------------------------|--------------------------|----------------------------------|
+| `qos_rw_iops`          | `simplybk/qos-rw-iops`   | Max read+write IOPS              |
+| `qos_rw_mbytes`        | `simplybk/qos-rw-mbytes` | Max read+write throughput (MB/s) |
+| `qos_r_mbytes`         | `simplybk/qos-r-mbytes`  | Max read throughput (MB/s)       |
+| `qos_w_mbytes`         | `simplybk/qos-w-mbytes`  | Max write throughput (MB/s)      |
 
 !!! note
-    Annotation values override StorageClass values per parameter. You can annotate only the ones you want to override.
+    Annotation values override StorageClass values per parameter. You must only use annotations for values you want to
+    override.

--- a/docs/usage/simplyblock-csi/quality-of-service.md
+++ b/docs/usage/simplyblock-csi/quality-of-service.md
@@ -4,12 +4,13 @@ description: "Defining Quality of Service: Simplyblock's Kubernetes CSI driver s
 weight: 40600
 ---
 
-Simplyblock's Kubernetes CSI driver supports Quality of Service (QoS) to define minimum guaranteed performance
-characteristics of a logical volume.
+Simplyblock's CSI driver supports QoS limits on logical volumes. There are two ways to set them.
 
-To define the QoS properties, create a [StorageClass](storage-class.md) with the required parameters.
+## Option 1: StorageClass
 
-```yaml title="StorageClass with Quality of Service"
+QoS applies to all volumes using the StorageClass. Values are fixed at creation time.
+
+```yaml title="StorageClass with QoS"
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -20,16 +21,43 @@ parameters:
   qos_rw_mbytes: 125
   qos_r_mbytes: 125
   qos_w_mbytes: 125
-  ... other parameters
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 ```
 
-The available parameters are:
+## Option 2: PVC Annotations
 
-| Parameter Name            | Value Type | Description                                                                                                                         | Optional | Default  |
-|---------------------------|------------|-------------------------------------------------------------------------------------------------------------------------------------|----------|----------|
-| qos_rw_iops               | int        | Defines the maximum IOPS reserved for a logical volume of this storage class. A zero (0) means no maximum.                          | true     | 0        |
-| qos_rw_mbytes             | int        | Defines the maximum total throughput in megabytes reserved for a logical volume of this storage class. A zero (0) means no maximum. | true     | 0        |
-| qos_r_mbytes              | int        | Defines the maximum read throughput in megabytes reserved for a logical volume of this storage class. A zero (0) means no maximum.  | true     | 0        |
-| qos_w_mbytes              | int        | Defines the maximum write throughput in megabytes reserved for a logical volume of this storage class. A zero (0) means no maximum. | true     | 0        |
+Use this for per-volume QoS without creating a dedicated StorageClass. Set annotations on the PVC before it is provisioned — values are locked in at volume creation time.
+
+```yaml title="PVC with QoS annotations"
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: my-pvc
+  annotations:
+    simplybk/qos-rw-iops: "1000"
+    simplybk/qos-rw-mbytes: "125"
+    simplybk/qos-r-mbytes: "125"
+    simplybk/qos-w-mbytes: "125"
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: simplyblock-csi-sc
+```
+
+## QoS Parameters
+
+All parameters are optional. Default is `0` (no limit).
+
+| Parameter / Annotation          | Description                          |
+|---------------------------------|--------------------------------------|
+| `qos_rw_iops` / `simplybk/qos-rw-iops`       | Max read+write IOPS      |
+| `qos_rw_mbytes` / `simplybk/qos-rw-mbytes`   | Max read+write throughput (MB/s) |
+| `qos_r_mbytes` / `simplybk/qos-r-mbytes`     | Max read throughput (MB/s)  |
+| `qos_w_mbytes` / `simplybk/qos-w-mbytes`     | Max write throughput (MB/s) |
+
+!!! note
+    Annotation values override StorageClass values per parameter. You can annotate only the ones you want to override.


### PR DESCRIPTION
CSI driver supports overriding QOS parameters via PVC annotations

This changes was introduced in https://github.com/simplyblock/simplyblock-csi/pull/294