### PR TITLE
Update SCC permissions for simplyblock deployment

### DIFF
--- a/docs/deployments/kubernetes/openshift.md
+++ b/docs/deployments/kubernetes/openshift.md
@@ -20,7 +20,8 @@ Ensure your OpenShift cluster is operational and that you have administrator pri
 Before deploying simplyblock components, grant the required SCC permissions:
 
 ```bash title="Grant SCC permissions"
-oc adm policy add-scc-to-group privileged system:serviceaccounts
+oc adm policy add-scc-to-user privileged -z simplyblock-csi-node-sa -n simplyblock
+oc adm policy add-scc-to-user privileged -z simplyblock-csi-controller-sa -n simplyblock
 ```
 
 This step is mandatory to allow SPDK and storage-related containers to run with the privileges required for NVMe device


### PR DESCRIPTION
Added commands to grant SCC permissions for specific service accounts instead of the all service accounts group.

This is to ensure only the additional permissions are granted to SimplyBlock and not all service accounts in the OpenShift cluster. 