### PR TITLE
docs: clarify erasure-coding schema is cluster-level, not per-volume

### DIFF
--- a/docs/deployments/cluster-deployment-options.md
+++ b/docs/deployments/cluster-deployment-options.md
@@ -17,8 +17,8 @@ It is recommended on shared networks and networks below 100gb/s.
 
 ### ```--data-chunks-per-stripe, --parity-chunks-per-stripe```
 
-Those two parameters together make up the default erasure coding schema of the node (e.g. 1+1, 2+2, 4+2). Starting from R25.10, it is also
-possible to set individual schemas per volume, but this feature is still in alpha-stage.
+Those two parameters together make up the erasure coding schema of the cluster (e.g. 1+1, 2+2, 4+2). The schema is set
+once at cluster creation and applies to all volumes in the cluster. It cannot be configured per volume.
 
 ### ```--cap-warn, --cap-crit```
 

--- a/docs/deployments/linux-initiators/index.md
+++ b/docs/deployments/linux-initiators/index.md
@@ -75,21 +75,20 @@ To create a new logical volume, the following command can be run on any control 
   --max-rw-iops <IOPS> \
   --max-r-mbytes <THROUGHPUT> \
   --max-w-mbytes <THROUGHPUT> \
-  --data-chunks-per-stripe <DATA CHUNKS IN STRIPE> \
-  --parity-chunks-per-stripe <PARITY CHUNKS IN STRIPE>
-  --fabric {tcp, rdma}
-  --lvol-priority-class <1-6>
+  --fabric {tcp, rdma} \
+  --lvol-priority-class <1-6> \
   <VOLUME_NAME> \
   <VOLUME_SIZE> \
   <POOL_NAME>
 ```
 
 !!! info
-    The parameters `data-chunks-per-stripe` and `parity-chunks-per-stripe` define the erasure-coding schema
-    (e.g., `--data-chunks-per-stripe=4 --parity-chunks-per-stripe=2`). The settings are optional. If not specified,
-    the cluster default is chosen. Valid for `data-chunks-per-stripe` are 1, 2, and 4, and for `parity-chunks-per-stripe`
-    0,1, and 2. However, it must be considered that the number of cluster nodes must be equal to or larger than
-    (`data-chunks-per-stripe` + `parity-chunks-per-stripe`).
+    The erasure-coding schema (the number of data and parity chunks per stripe) is not configured per volume. It is a
+    cluster-level setting that is defined once when the cluster is created, via the `--data-chunks-per-stripe` and
+    `--parity-chunks-per-stripe` options of the cluster deployment. All volumes inherit the cluster's erasure-coding
+    schema. For details on the available schemas and how to choose one, see
+    [Erasure Coding Scheme](../deployment-preparation/erasure-coding-scheme.md) and
+    [Cluster Deployment Options](../cluster-deployment-options.md).
 
     The parameter `--fabric` defines the fabric by which the volume is connected to the cluster. It is optional and the
     default is `tcp`. The fabric type `rdma` can only be chosen for hosts with an RDMA-capable NIC and for clusters that
@@ -98,8 +97,6 @@ To create a new logical volume, the following command can be run on any control 
 
 ```plain title="Example of creating a logical volume"
 {{ cliname }} volume add \
-  --data-chunks-per-stripe 2 \
-  --parity-chunks-per-stripe 1 \
   --fabric tcp lvol01 1000G test  
 ```
 

--- a/docs/deployments/linux-initiators/index.md
+++ b/docs/deployments/linux-initiators/index.md
@@ -4,20 +4,20 @@ description: "Plain Linux Initiators: Simplyblock storage can be attached over t
 weight: 20200
 ---
 
-Simplyblock storage can be attached over the network to Linux hosts which are not running Kubernetes, Proxmox or
+Simplyblock storage can be attached over the network to Linux hosts that are not running Kubernetes, Proxmox, or
 OpenStack.
 
-While no simplyblock components must be installed on these hosts, some OS-level configuration steps are required.
+While no simplyblock components need to be installed on these hosts, some OS-level configuration steps are required.
 Those manual steps are typically taken care of by the CSI driver or Proxmox integration.
 
-On plain Linux initiators, those steps have to be performed manually on each host that will connect simplyblock logical
+On plain Linux initiators, those steps must be performed manually on each host that will connect simplyblock logical
 volumes.
 
 ### Prerequisites
 
-Before starting the deployment, make sure that the following prerequisites as described in the
+Before starting the deployment, make sure that the prerequisites described in the
 [hardware prerequisites](../deployment-preparation/hardware-requirements.md) and
-[software prerequisites](../deployment-preparation/software-requirements.md) section are met.
+[software prerequisites](../deployment-preparation/software-requirements.md) sections are met.
 
 ### Install NVMe Client Package
 
@@ -42,7 +42,7 @@ For NVMe over TCP and NVMe over RoCE:
 ### Create a Storage Pool
 
 Before logical volumes can be created and connected, a storage pool is required. If a pool already exists, it can be
-reused. Otherwise, creating a storage pool can be created on any control plane node as follows:
+reused. Otherwise, a storage pool can be created on any control plane node as follows:
 
 ```bash title="Create a Storage Pool"
 {{ cliname }} storage-pool add <POOL_NAME> <CLUSTER_UUID>
@@ -56,7 +56,7 @@ To enable NVMe-oF security for all volumes in the pool, provide the `--dhchap` f
 
 For more information, see [NVMe-oF Security](../../architecture/concepts/nvmf-security.md).
 
-The last line of a successful storage pool creation returns the new pool id.
+The last line of a successful storage pool creation returns the new pool ID.
 
 ```plain title="Example output of creating a storage pool"
 [demo@demo ~]# {{ cliname }} storage-pool add test 4502977c-ae2d-4046-a8c5-ccc7fa78eb9a
@@ -84,9 +84,10 @@ To create a new logical volume, the following command can be run on any control 
 
 !!! info
     The erasure-coding schema (the number of data and parity chunks per stripe) is not configured per volume. It is a
-    cluster-level setting that is defined once when the cluster is created, via the `--data-chunks-per-stripe` and
-    `--parity-chunks-per-stripe` options of the cluster deployment. All volumes inherit the cluster's erasure-coding
-    schema. For details on the available schemas and how to choose one, see
+    cluster-level setting defined once during a cluster created. Configuration happens via the `--data-chunks-per-stripe` and
+    `--parity-chunks-per-stripe` options of the cluster deployment.
+
+    All volumes inherit the cluster's erasure-coding schema. For details on the available schemas and how to choose one, see
     [Erasure Coding Scheme](../deployment-preparation/erasure-coding-scheme.md) and
     [Cluster Deployment Options](../cluster-deployment-options.md).
 
@@ -100,12 +101,12 @@ To create a new logical volume, the following command can be run on any control 
   --fabric tcp lvol01 1000G test  
 ```
 
-In this example, a logical volume with the name `lvol01` and 1TB of thinly provisioned capacity is created in the pool
-named `test`. The uuid of the logical volume is returned at the end of the operation.
+In this example, a logical volume named `lvol01` with 1 TB of thinly provisioned capacity is created in the pool
+named `test`. The UUID of the logical volume is returned at the end of the operation.
 
 For additional parameters, see [the CLI reference](../../reference/cli/index.md).
 
-To connect a logical volume on the initiator (or Linux client), execute the following command on a any control plane
+To connect a logical volume on the initiator (or Linux client), execute the following command on any control plane
 node. This command returns one or more connection commands to be executed on the client.
 
 ```bash title="Get Volume Connection Commands"
@@ -137,4 +138,4 @@ sudo nvme connect --reconnect-delay=2 --ctrl-loss-tmo=3600 \
   --nqn=nqn.2023-02.io.simplyblock:fa66b0a0-477f-46be-8db5-b1e3a32d771a:lvol:a898b44d-d7ee-41bb-bc0a-989ad4711780
 ```
 
-The output can be copy-pasted to the host to which the volumes should be attached.
+The output can be copied and pasted to the host to which the volumes should be attached.


### PR DESCRIPTION
## What

The Linux initiators [Create and Connect a Logical Volume](https://docs.simplyblock.io/dev/deployments/linux-initiators/#create-and-connect-a-logical-volume) instructions documented `--data-chunks-per-stripe` and `--parity-chunks-per-stripe` as per-volume flags on `volume add`. Configuring the erasure-coding schema per volume is **not supported** — it is a cluster-level setting defined once at cluster creation, and all volumes inherit it.

## Changes

- **`docs/deployments/linux-initiators/index.md`**: Remove the per-volume chunk flags from the `volume add` command and the example, and rewrite the info note to explain the erasure-coding schema is inherited from the cluster (with links to *Erasure Coding Scheme* and *Cluster Deployment Options*). Also tidied the missing line-continuation backslashes in the command block.
- **`docs/deployments/cluster-deployment-options.md`**: Fix the `--data-chunks-per-stripe, --parity-chunks-per-stripe` note that incorrectly stated per-volume schemas could be set (previously described as an alpha feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)