### PR TITLE
docs(nvmf-security): remove inaccurate cluster-level security config

### DIFF
--- a/docs/architecture/concepts/nvmf-security.md
+++ b/docs/architecture/concepts/nvmf-security.md
@@ -5,8 +5,9 @@ weight: 30200
 ---
 
 Simplyblock supports NVMe-oF transport security to protect data in transit and restrict access to storage subsystems.
-Security is configured at two levels: cluster-wide settings define the authentication parameters, while pool-level
-settings control which security keys are generated for volumes and their allowed hosts.
+Security is enabled at the pool level: turning it on for a pool applies it to every volume created in that pool. Host
+access control and the per-host security keys are then managed per volume. There is no cluster-level security
+configuration — the DH-HMAC-CHAP parameters are fixed and need not (and cannot) be set when creating a cluster.
 
 ## Host Access Control
 
@@ -31,9 +32,10 @@ Simplyblock supports:
 - **Bidirectional (mutual) authentication**: Both host and target verify each other using a `dhchap_key` (host-to-target)
   and a `dhchap_ctrlr_key` (target-to-host).
 
-Supported hash algorithms (digests): `sha256`, `sha384`, `sha512`
+Simplyblock uses a fixed DH-HMAC-CHAP configuration; these parameters are not configurable:
 
-Supported Diffie-Hellman groups: `null`, `ffdhe2048`, `ffdhe3072`, `ffdhe4096`, `ffdhe6144`, `ffdhe8192`
+- Hash algorithms (digests) offered to the host: `sha256`, `sha384`, `sha512` (the host negotiates one).
+- Diffie-Hellman group: `ffdhe2048`.
 
 DH-HMAC-CHAP keys are automatically generated in the NVMe TP8018 format (`DHHC-1:<hash_id>:<base64(key)>:`) when
 a host is added to a volume in a pool with `dhchap_key` enabled in its security options.
@@ -48,12 +50,8 @@ PSK keys are automatically generated (256-bit random hex tokens) when a host is 
 
 ## Configuration Levels
 
-NVMe-oF security is configured at two levels:
-
-### Cluster Level
-
-At cluster creation time, DH-HMAC-CHAP parameters (digest algorithms and DH groups) are automatically provisioned. No
-specific configuration is required.
+NVMe-oF security is configured at the pool level and managed per volume/host. It is **not** configured at the cluster
+level — a cluster carries no security settings, and there is no `--host-sec` (or equivalent) option on `cluster create`.
 
 ### Pool Level
 

--- a/docs/architecture/concepts/nvmf-security.md
+++ b/docs/architecture/concepts/nvmf-security.md
@@ -5,9 +5,9 @@ weight: 30200
 ---
 
 Simplyblock supports NVMe-oF transport security to protect data in transit and restrict access to storage subsystems.
-Security is enabled at the pool level: turning it on for a pool applies it to every volume created in that pool. Host
-access control and the per-host security keys are then managed per volume. There is no cluster-level security
-configuration — the DH-HMAC-CHAP parameters are fixed and need not (and cannot) be set when creating a cluster.
+Security is enabled at a storage pool level. Turning it on for a storage pool applies to all volume created in that
+specific storage pool. Host access control and the per-host security keys are then managed per volume. There is no
+cluster-level security configuration. The DH-HMAC-CHAP parameters are fixed and cannot be set when creating a cluster.
 
 ## Host Access Control
 
@@ -32,9 +32,9 @@ Simplyblock supports:
 - **Bidirectional (mutual) authentication**: Both host and target verify each other using a `dhchap_key` (host-to-target)
   and a `dhchap_ctrlr_key` (target-to-host).
 
-Simplyblock uses a fixed DH-HMAC-CHAP configuration; these parameters are not configurable:
+Simplyblock uses a fixed DH-HMAC-CHAP configuration. The following settings are used:
 
-- Hash algorithms (digests) offered to the host: `sha256`, `sha384`, `sha512` (the host negotiates one).
+- Hash algorithms (digests) offered to and negotiated by the host: `sha256`, `sha384`, `sha512`.
 - Diffie-Hellman group: `ffdhe2048`.
 
 DH-HMAC-CHAP keys are automatically generated in the NVMe TP8018 format (`DHHC-1:<hash_id>:<base64(key)>:`) when
@@ -50,8 +50,8 @@ PSK keys are automatically generated (256-bit random hex tokens) when a host is 
 
 ## Configuration Levels
 
-NVMe-oF security is configured at the pool level and managed per volume/host. It is **not** configured at the cluster
-level — a cluster carries no security settings, and there is no `--host-sec` (or equivalent) option on `cluster create`.
+NVMe-oF security is configured at the storage pool level and managed per volume/host. It is **not** configured at the cluster
+level. In simplyblock, a storage cluster itself carries no security settings.
 
 ### Pool Level
 


### PR DESCRIPTION
## What

The [NVMe over Fabrics Security](https://docs.simplyblock.io/dev/architecture/concepts/nvmf-security/) concept page claimed NVMe-oF security is configured partly at the **cluster level**. That is inaccurate — there is no cluster-level security configuration.

## Corrections (verified against control-plane code)

- **No cluster-level config.** `cluster create` has no `--host-sec` (or any security) option; the `cluster.dhchap` field is unused. Removed the "two levels / cluster-wide settings" intro framing and the **Cluster Level** subsection claiming DH-HMAC-CHAP parameters are provisioned at cluster creation.
- **DH-HMAC-CHAP parameters are fixed, not configurable.** Digests offered: `sha256`, `sha384`, `sha512`; DH group: `ffdhe2048` (`constants.py`: `DHCHAP_DIGESTS`, `DHCHAP_DHGROUP`). Replaced the list implying all DH groups are selectable.
- Security is enabled at the **pool** level (`--dhchap`) and managed **per volume/host**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)