### PR TITLE
docs(network-ports): de-duplicate rows and drop firewall ports

### DIFF
--- a/snippets/network-port-table.md
+++ b/snippets/network-port-table.md
@@ -1,16 +1,10 @@
-| Service                         | Direction         | Hosts   | Network | Port(s)                          | Protocol(s) |
-|---------------------------------|-------------------|---------|---------|----------------------------------|-------------|
-| ICMP                            | ingress           | control | Control | -                                | ICMP        |
-| spdk-http-proxy                 | egress            | control | Control | 5000                             | TCP         |
-| spdk-http-proxy                 | ingress           | storage | Control | 5000                             | TCP         |
-| spdk-firewall-proxy<sup>1</sup> | egress            | control | Control | 50001-50065                      | TCP         |
-| spdk-firewall-proxy<sup>1</sup> | ingress           | storage | Control | 50001-50065                      | TCP         |
-| nvmf (client-target)            | egress            | client  | Storage | 4420-4499                        | TCP         |
-| nvmf (internal)                 | ingress, egress   | storage | Storage | 4420-4499                        | TCP         |
-| FoundationDB                    | ingress           | control | Control | 4500                             | TCP         |
-| Control plane API               | egress            | control | Control | 80                               | TCP         |
-| Control plane RPC               | egress            | control | Control | 8080-9044                        | TCP         |
-| Control plane RPC               | ingress           | storage | Control | 8080-9044                        | TCP         |
-| Monitoring Stack                | ingress, egress   | control | Control | 12202, 13301, 13302, 9200, 9090  | TCP         |
-
-<p style="font-size: 12px; position: relative; top: -20px;"><sup>1</sup>Deprecated since 26.2.3</p>
+| Service              | Direction       | Hosts            | Network | Port(s)                          | Protocol(s) |
+|----------------------|-----------------|------------------|---------|----------------------------------|-------------|
+| ICMP                 | ingress         | control          | Control | -                                | ICMP        |
+| spdk-http-proxy      | ingress, egress | storage, control | Control | 5000                             | TCP         |
+| nvmf (client-target) | egress          | client           | Storage | 4420-4499                        | TCP         |
+| nvmf (internal)      | ingress, egress | storage          | Storage | 4420-4499                        | TCP         |
+| FoundationDB         | ingress         | control          | Control | 4500                             | TCP         |
+| Control plane API    | egress          | control          | Control | 80                               | TCP         |
+| Control plane RPC    | ingress, egress | storage, control | Control | 8080-9044                        | TCP         |
+| Monitoring Stack     | ingress, egress | control          | Control | 12202, 13301, 13302, 9200, 9090  | TCP         |


### PR DESCRIPTION
## What

Fixes the shared network port table (`snippets/network-port-table.md`, included in **install-cp** and **k8s-storage-plane**).

## Two problems

1. **Duplicated rows.** Each control↔storage flow was listed twice — one row for the egress end and one for the ingress end of the same service/port (`spdk-http-proxy` and `Control plane RPC`). Collapsed each pair into a single row (Direction `ingress, egress`, Hosts `storage, control`), matching the style already used by the `nvmf (internal)` and `Monitoring Stack` rows.
2. **Firewall ports no longer required.** Removed the `spdk-firewall-proxy` rows (`50001-50065`) and the deprecation footnote. Port blocking is now done in-band via the SPDK `nvmf_port_block` RPC (`port_block.set_port`), so no separate firewall-proxy port range needs to be opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)