### PR TITLE
Add Linux block device (lblk) mode documentation (experimental)

### DIFF
--- a/docs/architecture/concepts/linux-block-devices.md
+++ b/docs/architecture/concepts/linux-block-devices.md
@@ -6,11 +6,11 @@ weight: 30650
 
 {{ experimental }}
 
-A simplyblock storage cluster normally onboards storage as NVMe PCIe devices: at deployment, NVMe
-controllers are detected on the PCI bus, unbound from the kernel driver, and attached natively to the
-simplyblock storage plane container. The Linux block device mode (`lblk`) is an alternative,
-cluster-global device mode that accepts any Linux block device — SAS or SATA SSDs behind an HBA,
-virtualized disks (virtio, Xen), or cloud volumes such as Amazon EBS — without requiring NVMe
+Storage is normally onboarded by a simplyblock storage cluster as NVMe PCIe devices: at deployment,
+NVMe controllers are detected on the PCI bus, unbound from the kernel driver, and attached natively to
+the simplyblock storage plane container. The Linux block device mode (`lblk`) is an alternative,
+cluster-global device mode, in which any Linux block device is accepted — SAS or SATA SSDs behind an
+HBA, virtualized disks (virtio, Xen), or cloud volumes such as Amazon EBS — without requiring NVMe
 hardware at all.
 
 !!! warning
@@ -51,11 +51,11 @@ A block device is eligible for `lblk` onboarding if all of the following hold:
 ## Device Identity
 
 NVMe devices are re-identified across reboots and restarts by their PCIe address and serial number.
-Linux block device names (`/dev/sdb`, `/dev/xvdc`, ...) are not stable across reboots, so `lblk` mode
-uses a serial-first identity: the device serial number (or WWN) is the primary identity, persisted in
-the cluster database at node addition. On every node restart, the stored serial is re-resolved
-against the live host inventory; the stored device name is only used as a fallback for devices that
-expose no serial. A device without any hardware serial receives a stable synthetic identifier at
+Linux block device names (`/dev/sdb`, `/dev/xvdc`, ...) are not stable across reboots, so a
+serial-first identity is used in `lblk` mode: the device serial number (or WWN) is the primary
+identity, persisted in the cluster database at node addition. On every node restart, the stored serial
+is re-resolved against the live host inventory; the stored device name is only used as a fallback for devices that
+expose no serial. A device without any hardware serial is given a stable synthetic identifier at
 configuration time.
 
 Renaming — for example, two disks swapping kernel names after a reboot — is therefore harmless: the
@@ -63,26 +63,27 @@ devices are matched by serial, and the storage stack is rebuilt on the correct d
 
 ## Failure Detection and Handling
 
-Device failure handling in `lblk` mode reaches parity with the NVMe path. IO errors on a device are
-detected by the storage stack exactly as in NVMe mode and feed the same device state machine:
-repeated errors mark the device unavailable, and a device that keeps failing is removed from the
-cluster map, with an automatic data migration rebuilding its data from redundancy onto the remaining
-devices. A device that disappears from the host — through hot removal or a cloud volume detach — is
+Device failure handling in `lblk` mode is at parity with the NVMe path. IO errors on a device are
+detected by the storage stack exactly as in NVMe mode and are fed into the same device state machine:
+a device is marked unavailable after repeated errors, and a device that keeps failing is removed from
+the cluster map, with its data rebuilt from redundancy onto the remaining devices by an automatic data
+migration. A device that disappears from the host — through hot removal or a cloud volume detach — is
 detected by inventory sweeps and handled like an NVMe hot-remove event.
 
-Hung IO is covered separately. The SPDK native NVMe driver enforces an IO timeout that converts stuck
-IO into failed IO; AIO bdevs have no such timeout, so `lblk` mode adds a control-plane hung-IO
-watchdog. Queue-depth sampling detects a device whose IO has made no progress for a sustained window
-(30 seconds by default) and marks it unavailable, feeding the same recovery machinery. Kernel-level
-SCSI and NVMe timeouts typically convert device stalls into IO errors well before this watchdog
-fires; it exists as the safety net for devices that hang without erroring.
+Hung IO is covered separately. An IO timeout is enforced by the SPDK native NVMe driver, by which
+stuck IO is converted into failed IO; AIO bdevs have no such timeout, so a control-plane hung-IO
+watchdog is added in `lblk` mode. A device whose IO has made no progress for a sustained window
+(30 seconds by default) is detected by queue-depth sampling and marked unavailable, entering the same
+recovery machinery. Device stalls are typically converted into IO errors by kernel-level SCSI and
+NVMe timeouts well before this watchdog fires; it exists as the safety net for devices that hang
+without erroring.
 
 ## Restrictions
 
 The device mode is cluster-global and deploy-time only: `nvme` and `lblk` devices cannot be mixed
-within one cluster, and the mode cannot be changed after cluster creation. `lblk` mode requires
-journal-on-device deployment (a dedicated device for the journal); device partitioning is not
-supported. Growing a node's device set at restart time is not supported either — see
+within one cluster, and the mode cannot be changed after cluster creation. In `lblk` mode,
+journal-on-device deployment (a dedicated device for the journal) is required; device partitioning is
+not supported. Growing a node's device set at restart time is not supported either — see
 [Linux Block Device Operations](../../non-kubernetes/operations/lblk-device-operations.md).
 
 SMART health telemetry is not available for AIO-backed devices. Device-level performance depends on

--- a/docs/architecture/concepts/linux-block-devices.md
+++ b/docs/architecture/concepts/linux-block-devices.md
@@ -1,16 +1,17 @@
 ---
 title: "Linux Block Devices (lblk)"
-description: "How simplyblock clusters use arbitrary Linux block devices, such as SAS or SATA SSDs and cloud volumes, through SPDK AIO bdevs instead of NVMe."
+description: "How simplyblock clusters use arbitrary Linux block devices, such as SAS or SATA SSDs and cloud volumes, instead of NVMe PCIe devices."
 weight: 30650
 ---
 
 {{ experimental }}
 
 A simplyblock storage cluster normally onboards storage as NVMe PCIe devices: at deployment, NVMe
-controllers are detected on the PCI bus, unbound from the kernel driver, and attached natively by
-SPDK. The Linux block device mode (`lblk`) is an alternative, cluster-global device mode that accepts
-any Linux block device — SAS or SATA SSDs behind an HBA, virtualized disks (virtio, Xen), or cloud
-volumes such as Amazon EBS — without requiring NVMe hardware at all.
+controllers are detected on the PCI bus, unbound from the kernel driver, and attached natively to the
+Simplyblock Storage Plane Container. The Linux block device mode (`lblk`) is an alternative,
+cluster-global device mode that accepts any Linux block device — SAS or SATA SSDs behind an HBA,
+virtualized disks (virtio, Xen), or cloud volumes such as Amazon EBS — without requiring NVMe
+hardware at all.
 
 !!! warning
     Linux block device support is experimental. It is intended for evaluation, for test environments,
@@ -27,14 +28,12 @@ cluster:
 | `nvme` (default) | NVMe PCIe SSDs | SPDK native NVMe driver (kernel driver unbind) |
 | `lblk` | Any Linux disk-type block device | SPDK AIO bdev on top of the kernel block layer |
 
-In `lblk` mode, each selected device is wrapped in one SPDK AIO bdev. Everything above the base
-device — journaling, [erasure coding](erasure-coding.md), logical volume stores, and NVMe-oF export —
-is identical in both modes, because the storage stack is device-agnostic from the device abstraction
-layer upward. The inter-node fabric is unaffected: nodes still interconnect via NVMe/TCP or RDMA, and
-clients still connect via NVMe-oF, regardless of the device mode.
+In `lblk` mode, Linux block devices can be selected by their block device name (either allow or deny
+lists) or by their serial number at deploy time. The deployment process and cluster operations are
+otherwise identical.
 
 Because the devices remain owned by the Linux kernel in `lblk` mode, no kernel driver unbinding takes
-place, and no device is ever claimed by SPDK's PCI layer.
+place, and no device is ever claimed by the Simplyblock Storage Plane PCI layer.
 
 ## Device Eligibility
 

--- a/docs/architecture/concepts/linux-block-devices.md
+++ b/docs/architecture/concepts/linux-block-devices.md
@@ -6,12 +6,13 @@ weight: 30650
 
 {{ experimental }}
 
-Storage is normally onboarded by a simplyblock storage cluster as NVMe PCIe devices: at deployment,
+Storage is onboarded by a simplyblock storage cluster as NVMe PCIe devices by default. At deployment,
 NVMe controllers are detected on the PCI bus, unbound from the kernel driver, and attached natively to
-the simplyblock storage plane container. The Linux block device mode (`lblk`) is an alternative,
-cluster-global device mode, in which any Linux block device is accepted without requiring NVMe
-hardware at all: SAS or SATA SSDs behind an HBA, virtualized disks (virtio, Xen), or cloud volumes
-such as Amazon EBS.
+the simplyblock storage plane container.
+
+The Linux block device mode (`lblk`) is an alternative, cluster-global device mode. In it, any Linux
+block device is accepted and no NVMe hardware is required at all: SAS or SATA SSDs behind an HBA,
+virtualized disks (virtio, Xen), or cloud volumes such as Amazon EBS.
 
 !!! warning
     Linux block device support is experimental. It is intended for evaluation, for test environments,
@@ -28,8 +29,8 @@ cluster:
 | `nvme` (default) | NVMe PCIe SSDs | SPDK native NVMe driver (kernel driver unbind) |
 | `lblk` | Any Linux disk-type block device | SPDK AIO bdev on top of the kernel block layer |
 
-In `lblk` mode, Linux block devices can be selected by their block device name (either allow or deny
-lists) or by their serial number at deploy time. The deployment process and cluster operations are
+In `lblk` mode, devices can be selected at deploy time by their block device name (through an allow
+list or a deny list) or by their serial number. The deployment process and cluster operations are
 otherwise identical.
 
 Because the devices remain owned by the Linux kernel in `lblk` mode, no kernel driver unbinding takes
@@ -51,15 +52,16 @@ A block device is eligible for `lblk` onboarding if all of the following hold:
 ## Device Identity
 
 NVMe devices are re-identified across reboots and restarts by their PCIe address and serial number.
-Linux block device names (`/dev/sdb`, `/dev/xvdc`, ...) are not stable across reboots, so a
-serial-first identity is used in `lblk` mode: the device serial number (or WWN) is the primary
-identity, persisted in the cluster database at node addition. On every node restart, the stored serial
-is re-resolved against the live host inventory. The stored device name is only used as a fallback for
-devices that expose no serial. A device without any hardware serial is given a stable synthetic identifier at
-configuration time.
+Linux block device names (`/dev/sdb`, `/dev/xvdc`) are not stable across reboots, so a serial-first
+identity is used in `lblk` mode instead.
 
-Renaming (for example, two disks swapping kernel names after a reboot) is therefore harmless: the
-devices are matched by serial, and the storage stack is rebuilt on the correct disks.
+The primary identity is the device serial number (or WWN), persisted in the cluster database at node
+addition and re-resolved against the live host inventory on every node restart. The stored device
+name serves only as a fallback for devices that expose no serial, and a device without any hardware
+serial is given a stable synthetic identifier at configuration time.
+
+Renaming is therefore harmless. Two disks that swap kernel names after a reboot are still matched by
+serial, and the storage stack is rebuilt on the correct disks.
 
 ## Failure Detection and Handling
 
@@ -67,23 +69,23 @@ Device failure handling in `lblk` mode is at parity with the NVMe path. IO error
 detected by the storage stack exactly as in NVMe mode and are fed into the same device state machine:
 a device is marked unavailable after repeated errors, and a device that keeps failing is removed from
 the cluster map, with its data rebuilt from redundancy onto the remaining devices by an automatic data
-migration. A device that disappears from the host (through hot removal or a cloud volume detach) is
+migration. A device that disappears from the host, through hot removal or a cloud volume detach, is
 detected by inventory sweeps and handled like an NVMe hot-remove event.
 
-Hung IO is covered separately. An IO timeout is enforced by the SPDK native NVMe driver, by which
-stuck IO is converted into failed IO. AIO bdevs have no such timeout, so a control-plane hung-IO
-watchdog is added in `lblk` mode. A device whose IO has made no progress for a sustained window
-(30 seconds by default) is detected by queue-depth sampling and marked unavailable, entering the same
-recovery machinery. Device stalls are typically converted into IO errors by kernel-level SCSI and
-NVMe timeouts well before this watchdog fires. It exists as the safety net for devices that hang
-without erroring.
+Hung IO is handled separately. An IO timeout is enforced by the SPDK native NVMe driver, by which
+stuck IO is converted into failed IO, but AIO bdevs have no such timeout. A control-plane hung-IO
+watchdog is therefore added in `lblk` mode: a device whose IO has made no progress for a sustained
+window (30 seconds by default) is detected by queue-depth sampling and marked unavailable, entering
+the same recovery machinery. The watchdog is the safety net for devices that hang without erroring,
+because device stalls are typically converted into IO errors by kernel-level SCSI and NVMe timeouts
+well before it fires.
 
 ## Restrictions
 
 The device mode is cluster-global and deploy-time only: `nvme` and `lblk` devices cannot be mixed
 within one cluster, and the mode cannot be changed after cluster creation. In `lblk` mode,
 journal-on-device deployment (a dedicated device for the journal) is required. Device partitioning is
-not supported, and growing a node's device set at restart time is not supported either (see
+not supported, and neither is growing a node's device set at restart time (see
 [Linux Block Device Operations](../../non-kubernetes/operations/lblk-device-operations.md)).
 
 SMART health telemetry is not available for AIO-backed devices. Device-level performance depends on

--- a/docs/architecture/concepts/linux-block-devices.md
+++ b/docs/architecture/concepts/linux-block-devices.md
@@ -9,9 +9,9 @@ weight: 30650
 Storage is normally onboarded by a simplyblock storage cluster as NVMe PCIe devices: at deployment,
 NVMe controllers are detected on the PCI bus, unbound from the kernel driver, and attached natively to
 the simplyblock storage plane container. The Linux block device mode (`lblk`) is an alternative,
-cluster-global device mode, in which any Linux block device is accepted — SAS or SATA SSDs behind an
-HBA, virtualized disks (virtio, Xen), or cloud volumes such as Amazon EBS — without requiring NVMe
-hardware at all.
+cluster-global device mode, in which any Linux block device is accepted without requiring NVMe
+hardware at all: SAS or SATA SSDs behind an HBA, virtualized disks (virtio, Xen), or cloud volumes
+such as Amazon EBS.
 
 !!! warning
     Linux block device support is experimental. It is intended for evaluation, for test environments,
@@ -39,8 +39,8 @@ place, and no device is ever claimed by the simplyblock storage plane PCI layer.
 
 A block device is eligible for `lblk` onboarding if all of the following hold:
 
-- It is a whole disk — not a partition, and not a special device such as a loop, RAM, CD-ROM, or
-  device-mapper device.
+- It is a whole disk (not a partition, and not a special device such as a loop, RAM, CD-ROM, or
+  device-mapper device).
 - It is not mounted, and no partition of it is mounted.
 - It is not held by another subsystem (LVM, MD RAID, or device-mapper).
 - It is not the root disk.
@@ -54,11 +54,11 @@ NVMe devices are re-identified across reboots and restarts by their PCIe address
 Linux block device names (`/dev/sdb`, `/dev/xvdc`, ...) are not stable across reboots, so a
 serial-first identity is used in `lblk` mode: the device serial number (or WWN) is the primary
 identity, persisted in the cluster database at node addition. On every node restart, the stored serial
-is re-resolved against the live host inventory; the stored device name is only used as a fallback for devices that
-expose no serial. A device without any hardware serial is given a stable synthetic identifier at
+is re-resolved against the live host inventory. The stored device name is only used as a fallback for
+devices that expose no serial. A device without any hardware serial is given a stable synthetic identifier at
 configuration time.
 
-Renaming — for example, two disks swapping kernel names after a reboot — is therefore harmless: the
+Renaming (for example, two disks swapping kernel names after a reboot) is therefore harmless: the
 devices are matched by serial, and the storage stack is rebuilt on the correct disks.
 
 ## Failure Detection and Handling
@@ -67,24 +67,24 @@ Device failure handling in `lblk` mode is at parity with the NVMe path. IO error
 detected by the storage stack exactly as in NVMe mode and are fed into the same device state machine:
 a device is marked unavailable after repeated errors, and a device that keeps failing is removed from
 the cluster map, with its data rebuilt from redundancy onto the remaining devices by an automatic data
-migration. A device that disappears from the host — through hot removal or a cloud volume detach — is
+migration. A device that disappears from the host (through hot removal or a cloud volume detach) is
 detected by inventory sweeps and handled like an NVMe hot-remove event.
 
 Hung IO is covered separately. An IO timeout is enforced by the SPDK native NVMe driver, by which
-stuck IO is converted into failed IO; AIO bdevs have no such timeout, so a control-plane hung-IO
+stuck IO is converted into failed IO. AIO bdevs have no such timeout, so a control-plane hung-IO
 watchdog is added in `lblk` mode. A device whose IO has made no progress for a sustained window
 (30 seconds by default) is detected by queue-depth sampling and marked unavailable, entering the same
 recovery machinery. Device stalls are typically converted into IO errors by kernel-level SCSI and
-NVMe timeouts well before this watchdog fires; it exists as the safety net for devices that hang
+NVMe timeouts well before this watchdog fires. It exists as the safety net for devices that hang
 without erroring.
 
 ## Restrictions
 
 The device mode is cluster-global and deploy-time only: `nvme` and `lblk` devices cannot be mixed
 within one cluster, and the mode cannot be changed after cluster creation. In `lblk` mode,
-journal-on-device deployment (a dedicated device for the journal) is required; device partitioning is
-not supported. Growing a node's device set at restart time is not supported either — see
-[Linux Block Device Operations](../../non-kubernetes/operations/lblk-device-operations.md).
+journal-on-device deployment (a dedicated device for the journal) is required. Device partitioning is
+not supported, and growing a node's device set at restart time is not supported either (see
+[Linux Block Device Operations](../../non-kubernetes/operations/lblk-device-operations.md)).
 
 SMART health telemetry is not available for AIO-backed devices. Device-level performance depends on
 the underlying block device and the kernel block layer, so higher latency than with SPDK-native NVMe

--- a/docs/architecture/concepts/linux-block-devices.md
+++ b/docs/architecture/concepts/linux-block-devices.md
@@ -1,0 +1,91 @@
+---
+title: "Linux Block Devices (lblk)"
+description: "How simplyblock clusters use arbitrary Linux block devices, such as SAS or SATA SSDs and cloud volumes, through SPDK AIO bdevs instead of NVMe."
+weight: 30650
+---
+
+{{ experimental }}
+
+A simplyblock storage cluster normally onboards storage as NVMe PCIe devices: at deployment, NVMe
+controllers are detected on the PCI bus, unbound from the kernel driver, and attached natively by
+SPDK. The Linux block device mode (`lblk`) is an alternative, cluster-global device mode that accepts
+any Linux block device — SAS or SATA SSDs behind an HBA, virtualized disks (virtio, Xen), or cloud
+volumes such as Amazon EBS — without requiring NVMe hardware at all.
+
+!!! warning
+    Linux block device support is experimental. It is intended for evaluation, for test environments,
+    and for deployments where NVMe devices are unavailable. For production-grade performance, local
+    NVMe devices are recommended.
+
+## Device Modes
+
+The device mode is chosen once, at cluster creation, and applies to every storage node in the
+cluster:
+
+| Mode | Storage devices | Attachment |
+|------|-----------------|------------|
+| `nvme` (default) | NVMe PCIe SSDs | SPDK native NVMe driver (kernel driver unbind) |
+| `lblk` | Any Linux disk-type block device | SPDK AIO bdev on top of the kernel block layer |
+
+In `lblk` mode, each selected device is wrapped in one SPDK AIO bdev. Everything above the base
+device — journaling, [erasure coding](erasure-coding.md), logical volume stores, and NVMe-oF export —
+is identical in both modes, because the storage stack is device-agnostic from the device abstraction
+layer upward. The inter-node fabric is unaffected: nodes still interconnect via NVMe/TCP or RDMA, and
+clients still connect via NVMe-oF, regardless of the device mode.
+
+Because the devices remain owned by the Linux kernel in `lblk` mode, no kernel driver unbinding takes
+place, and no device is ever claimed by SPDK's PCI layer.
+
+## Device Eligibility
+
+A block device is eligible for `lblk` onboarding if all of the following hold:
+
+- It is a whole disk — not a partition, and not a special device such as a loop, RAM, CD-ROM, or
+  device-mapper device.
+- It is not mounted, and no partition of it is mounted.
+- It is not held by another subsystem (LVM, MD RAID, or device-mapper).
+- It is not the root disk.
+- It is not read-only and reports a non-zero size.
+- It is unpartitioned. A device with an existing partition table is only accepted if it is explicitly
+  force-formatted at node addition, which wipes the partition table and all filesystem signatures.
+
+## Device Identity
+
+NVMe devices are re-identified across reboots and restarts by their PCIe address and serial number.
+Linux block device names (`/dev/sdb`, `/dev/xvdc`, ...) are not stable across reboots, so `lblk` mode
+uses a serial-first identity: the device serial number (or WWN) is the primary identity, persisted in
+the cluster database at node addition. On every node restart, the stored serial is re-resolved
+against the live host inventory; the stored device name is only used as a fallback for devices that
+expose no serial. A device without any hardware serial receives a stable synthetic identifier at
+configuration time.
+
+Renaming — for example, two disks swapping kernel names after a reboot — is therefore harmless: the
+devices are matched by serial, and the storage stack is rebuilt on the correct disks.
+
+## Failure Detection and Handling
+
+Device failure handling in `lblk` mode reaches parity with the NVMe path. IO errors on a device are
+detected by the storage stack exactly as in NVMe mode and feed the same device state machine:
+repeated errors mark the device unavailable, and a device that keeps failing is removed from the
+cluster map, with an automatic data migration rebuilding its data from redundancy onto the remaining
+devices. A device that disappears from the host — through hot removal or a cloud volume detach — is
+detected by inventory sweeps and handled like an NVMe hot-remove event.
+
+Hung IO is covered separately. The SPDK native NVMe driver enforces an IO timeout that converts stuck
+IO into failed IO; AIO bdevs have no such timeout, so `lblk` mode adds a control-plane hung-IO
+watchdog. Queue-depth sampling detects a device whose IO has made no progress for a sustained window
+(30 seconds by default) and marks it unavailable, feeding the same recovery machinery. Kernel-level
+SCSI and NVMe timeouts typically convert device stalls into IO errors well before this watchdog
+fires; it exists as the safety net for devices that hang without erroring.
+
+## Restrictions
+
+The device mode is cluster-global and deploy-time only: `nvme` and `lblk` devices cannot be mixed
+within one cluster, and the mode cannot be changed after cluster creation. `lblk` mode requires
+journal-on-device deployment (a dedicated device for the journal); device partitioning is not
+supported. Growing a node's device set at restart time is not supported either — see
+[Linux Block Device Operations](../../non-kubernetes/operations/lblk-device-operations.md).
+
+SMART health telemetry is not available for AIO-backed devices. Device-level performance depends on
+the underlying block device and the kernel block layer, so higher latency than with SPDK-native NVMe
+attachment is to be expected.

--- a/docs/architecture/concepts/linux-block-devices.md
+++ b/docs/architecture/concepts/linux-block-devices.md
@@ -8,7 +8,7 @@ weight: 30650
 
 A simplyblock storage cluster normally onboards storage as NVMe PCIe devices: at deployment, NVMe
 controllers are detected on the PCI bus, unbound from the kernel driver, and attached natively to the
-Simplyblock Storage Plane Container. The Linux block device mode (`lblk`) is an alternative,
+simplyblock storage plane container. The Linux block device mode (`lblk`) is an alternative,
 cluster-global device mode that accepts any Linux block device — SAS or SATA SSDs behind an HBA,
 virtualized disks (virtio, Xen), or cloud volumes such as Amazon EBS — without requiring NVMe
 hardware at all.
@@ -33,7 +33,7 @@ lists) or by their serial number at deploy time. The deployment process and clus
 otherwise identical.
 
 Because the devices remain owned by the Linux kernel in `lblk` mode, no kernel driver unbinding takes
-place, and no device is ever claimed by the Simplyblock Storage Plane PCI layer.
+place, and no device is ever claimed by the simplyblock storage plane PCI layer.
 
 ## Device Eligibility
 

--- a/docs/non-kubernetes/installation/linux-block-devices.md
+++ b/docs/non-kubernetes/installation/linux-block-devices.md
@@ -7,7 +7,7 @@ weight: 35000
 {{ experimental }}
 
 Deploying a storage plane on Linux block devices instead of NVMe PCIe devices follows the standard
-[storage plane installation](install-sp.md) flow; only the differing steps are described here.
+[storage plane installation](install-sp.md) flow. Only the differing steps are described here.
 Background on the device mode, the eligibility rules, and the device identity is found under
 [Linux Block Devices (lblk)](../../architecture/concepts/linux-block-devices.md).
 
@@ -60,7 +60,7 @@ sudo {{ cliname }} storage-node configure --lblk --blk-names-exclude sda --max-l
 sudo {{ cliname }} storage-node configure --lblk --blk-serials S3EVNX0M602707,S3EVNX0M602708 --max-lvol 50
 ```
 
-A requested device that is busy — mounted, held, or otherwise ineligible — is an error: the
+A requested device that is busy (mounted, held, or otherwise ineligible) is an error: the
 configuration fails rather than silently skipping the device.
 
 The selected devices are stored in the resulting configuration file
@@ -102,11 +102,11 @@ sudo {{ cliname }} storage-node add-node --force-format <CLUSTER_ID> <NODE_IP>:5
     the node configuration has to be verified before the node is added.
 
 During node addition, each selected device is wrapped in an SPDK AIO bdev. No kernel driver unbinding
-takes place — the devices stay visible to the host OS but must not be used by anything else. The
+takes place, so the devices stay visible to the host OS but must not be used by anything else. The
 smallest device is used as the journal device, as in NVMe mode with journal-on-device deployments.
 
-Everything after node addition — cluster activation, pool creation, volume provisioning, and client
-connection — is identical to an NVMe-mode cluster.
+Everything after node addition (cluster activation, pool creation, volume provisioning, and client
+connection) is identical to an NVMe-mode cluster.
 
 ## Verification
 

--- a/docs/non-kubernetes/installation/linux-block-devices.md
+++ b/docs/non-kubernetes/installation/linux-block-devices.md
@@ -25,8 +25,8 @@ control plane:
 sudo {{ cliname }} cluster create --device-mode lblk
 ```
 
-`nvme` (the default) and `lblk` are accepted by `--device-mode`. The mode cannot be changed after
-creation, and it is followed by all storage nodes of the cluster.
+Two values are accepted by `--device-mode`: `nvme` (the default) and `lblk`. The mode is followed by
+all storage nodes of the cluster and cannot be changed after creation.
 
 !!! important
     All control plane and storage node services must run a software version that supports the `lblk`
@@ -41,12 +41,12 @@ and an optional device selector:
 sudo {{ cliname }} storage-node configure --lblk --max-lvol <MAX_LOGICAL_VOLUMES>
 ```
 
-Without a selector, every eligible disk on the host is used. Eligible means a whole, unmounted,
+Without a selector, every eligible disk on the host is used. An eligible disk is a whole, unmounted,
 unheld, and unpartitioned disk that is not the root disk (see the
 [eligibility rules](../../architecture/concepts/linux-block-devices.md#device-eligibility)).
 
-Devices can be selected explicitly by name or by serial number. The three selectors are mutually
-exclusive:
+Devices can also be selected explicitly, by name or by serial number. The three selectors are
+mutually exclusive:
 
 ```bash title="Selecting block devices by name"
 sudo {{ cliname }} storage-node configure --lblk --blk-names sdb,sdc --max-lvol 50
@@ -60,13 +60,13 @@ sudo {{ cliname }} storage-node configure --lblk --blk-names-exclude sda --max-l
 sudo {{ cliname }} storage-node configure --lblk --blk-serials S3EVNX0M602707,S3EVNX0M602708 --max-lvol 50
 ```
 
-A requested device that is busy (mounted, held, or otherwise ineligible) is an error: the
+A requested device that is busy (mounted, held, or otherwise ineligible) is an error. The
 configuration fails rather than silently skipping the device.
 
 The selected devices are stored in the resulting configuration file
 (`/etc/simplyblock/sn_config_file`) with their name, serial, stable by-id path, size, and NUMA
-assignment. As in NVMe mode, the file can be
-reviewed and manually edited before deployment, for example to remove a device from the selection.
+assignment. As in NVMe mode, the file can be reviewed and manually edited before deployment, for
+example to remove a device from the selection.
 
 ### Partitioned Devices
 
@@ -77,7 +77,7 @@ eligible with `--force` at configuration time:
 sudo {{ cliname }} storage-node configure --lblk --blk-names sdb --force --max-lvol 50
 ```
 
-The actual wipe happens later, at node addition, and must be requested there explicitly with
+The wipe itself happens later, at node addition, where it has to be requested explicitly with
 `--force-format`. Until then, no data is touched.
 
 ## Storage Node Deployment and Addition
@@ -88,10 +88,10 @@ Node deployment is unchanged:
 sudo {{ cliname }} storage-node deploy --ifname eth0
 ```
 
-Adding the node to the cluster from a control plane node is unchanged as well, with one additional
-flag: if partitioned devices were force-included at configuration time, with `--force-format` the
-node addition is instructed to wipe partition tables and filesystem signatures (`wipefs`) from those
-devices:
+Adding the node to the cluster from a control plane node is unchanged as well, apart from one
+additional flag. If partitioned devices were force-included at configuration time, with
+`--force-format` the node addition is instructed to wipe partition tables and filesystem signatures
+(`wipefs`) from those devices:
 
 ```bash title="Adding the storage node while wiping partitioned devices"
 sudo {{ cliname }} storage-node add-node --force-format <CLUSTER_ID> <NODE_IP>:5000 eth0
@@ -117,5 +117,5 @@ address:
 sudo {{ cliname }} storage-node list-devices <NODE_ID>
 ```
 
-On the host, the devices continue to be shown by `lsblk`, since they remain kernel-owned, and one
-`aio_<serial>` base bdev per device is exposed by the SPDK process.
+On the host, the devices remain kernel-owned and continue to be shown by `lsblk`. One `aio_<serial>`
+base bdev per device is exposed by the SPDK process.

--- a/docs/non-kubernetes/installation/linux-block-devices.md
+++ b/docs/non-kubernetes/installation/linux-block-devices.md
@@ -1,0 +1,119 @@
+---
+title: "Deploy with Linux Block Devices"
+description: "Deploying a simplyblock cluster on Linux block devices: cluster creation in lblk mode, device selection by name or serial, and node addition."
+weight: 35000
+---
+
+{{ experimental }}
+
+This page describes deploying a storage plane on Linux block devices instead of NVMe PCIe devices. It
+follows the standard [storage plane installation](install-sp.md) flow; only the differing steps are
+described here. Background on the device mode, the eligibility rules, and the device identity is
+found under [Linux Block Devices (lblk)](../../architecture/concepts/linux-block-devices.md).
+
+!!! warning
+    Linux block device support is experimental. It is intended for evaluation, for test environments,
+    and for deployments where NVMe devices are unavailable, such as cloud instances with attached
+    volumes only. For production-grade performance, local NVMe devices are recommended.
+
+## Cluster Creation
+
+The device mode is a cluster-global, deploy-time choice made when the cluster is created on the
+control plane:
+
+```bash title="Creating a cluster in lblk device mode"
+sudo {{ cliname }} cluster create --device-mode lblk
+```
+
+`--device-mode` accepts `nvme` (the default) and `lblk`. It cannot be changed after creation, and all
+storage nodes of the cluster follow it.
+
+!!! important
+    All control plane and storage node services must run a software version that supports the `lblk`
+    device mode before a cluster is created with it.
+
+## Storage Node Configuration
+
+On each storage node, devices are selected at `storage-node configure` time with the `--lblk` flag
+and an optional device selector:
+
+```bash title="Configuring a storage node with all eligible block devices"
+sudo {{ cliname }} storage-node configure --lblk --max-lvol <MAX_LOGICAL_VOLUMES>
+```
+
+Without a selector, every eligible disk on the host is used. Eligible means a whole, unmounted,
+unheld, and unpartitioned disk that is not the root disk (see the
+[eligibility rules](../../architecture/concepts/linux-block-devices.md#device-eligibility)).
+
+Devices can be selected explicitly by name or by serial number. The three selectors are mutually
+exclusive:
+
+```bash title="Selecting block devices by name"
+sudo {{ cliname }} storage-node configure --lblk --blk-names sdb,sdc --max-lvol 50
+```
+
+```bash title="Selecting all eligible block devices except some"
+sudo {{ cliname }} storage-node configure --lblk --blk-names-exclude sda --max-lvol 50
+```
+
+```bash title="Selecting block devices by serial number or WWN"
+sudo {{ cliname }} storage-node configure --lblk --blk-serials S3EVNX0M602707,S3EVNX0M602708 --max-lvol 50
+```
+
+A requested device that is busy — mounted, held, or otherwise ineligible — is an error: the
+configuration fails rather than silently skipping the device.
+
+The resulting configuration file (`/etc/simplyblock/sn_config_file`) stores the selected devices with
+their name, serial, stable by-id path, size, and NUMA assignment. As in NVMe mode, the file can be
+reviewed and manually edited before deployment, for example to remove a device from the selection.
+
+### Partitioned Devices
+
+A device carrying a partition table is not eligible by default. To reuse such a device, it is marked
+eligible with `--force` at configuration time:
+
+```bash title="Including a partitioned block device in the selection"
+sudo {{ cliname }} storage-node configure --lblk --blk-names sdb --force --max-lvol 50
+```
+
+The actual wipe happens later, at node addition, and must be requested there explicitly with
+`--force-format`. Until then, no data is touched.
+
+## Storage Node Deployment and Addition
+
+Node deployment is unchanged:
+
+```bash title="Deploying the storage node"
+sudo {{ cliname }} storage-node deploy --ifname eth0
+```
+
+Adding the node to the cluster from a control plane node is unchanged as well, with one additional
+flag: if partitioned devices were force-included at configuration time, `--force-format` instructs
+the node addition to wipe partition tables and filesystem signatures (`wipefs`) from those devices:
+
+```bash title="Adding the storage node while wiping partitioned devices"
+sudo {{ cliname }} storage-node add-node --force-format <CLUSTER_ID> <NODE_IP>:5000 eth0
+```
+
+!!! danger
+    `--force-format` irreversibly destroys any data on the affected devices. The device selection in
+    the node configuration has to be verified before the node is added.
+
+During node addition, each selected device is wrapped in an SPDK AIO bdev. No kernel driver unbinding
+takes place — the devices stay visible to the host OS but must not be used by anything else. The
+smallest device becomes the journal device, as in NVMe mode with journal-on-device deployments.
+
+Everything after node addition — cluster activation, pool creation, volume provisioning, and client
+connection — is identical to an NVMe-mode cluster.
+
+## Verification
+
+After activation, the devices are listed like NVMe devices, showing the device path instead of a PCIe
+address:
+
+```bash title="Listing the storage devices of a node"
+sudo {{ cliname }} storage-node list-devices <NODE_ID>
+```
+
+On the host, `lsblk` continues to show the devices, since they remain kernel-owned, and the SPDK
+process exposes one `aio_<serial>` base bdev per device.

--- a/docs/non-kubernetes/installation/linux-block-devices.md
+++ b/docs/non-kubernetes/installation/linux-block-devices.md
@@ -6,10 +6,10 @@ weight: 35000
 
 {{ experimental }}
 
-This page describes deploying a storage plane on Linux block devices instead of NVMe PCIe devices. It
-follows the standard [storage plane installation](install-sp.md) flow; only the differing steps are
-described here. Background on the device mode, the eligibility rules, and the device identity is
-found under [Linux Block Devices (lblk)](../../architecture/concepts/linux-block-devices.md).
+Deploying a storage plane on Linux block devices instead of NVMe PCIe devices follows the standard
+[storage plane installation](install-sp.md) flow; only the differing steps are described here.
+Background on the device mode, the eligibility rules, and the device identity is found under
+[Linux Block Devices (lblk)](../../architecture/concepts/linux-block-devices.md).
 
 !!! warning
     Linux block device support is experimental. It is intended for evaluation, for test environments,
@@ -25,8 +25,8 @@ control plane:
 sudo {{ cliname }} cluster create --device-mode lblk
 ```
 
-`--device-mode` accepts `nvme` (the default) and `lblk`. It cannot be changed after creation, and all
-storage nodes of the cluster follow it.
+`nvme` (the default) and `lblk` are accepted by `--device-mode`. The mode cannot be changed after
+creation, and it is followed by all storage nodes of the cluster.
 
 !!! important
     All control plane and storage node services must run a software version that supports the `lblk`
@@ -63,8 +63,9 @@ sudo {{ cliname }} storage-node configure --lblk --blk-serials S3EVNX0M602707,S3
 A requested device that is busy — mounted, held, or otherwise ineligible — is an error: the
 configuration fails rather than silently skipping the device.
 
-The resulting configuration file (`/etc/simplyblock/sn_config_file`) stores the selected devices with
-their name, serial, stable by-id path, size, and NUMA assignment. As in NVMe mode, the file can be
+The selected devices are stored in the resulting configuration file
+(`/etc/simplyblock/sn_config_file`) with their name, serial, stable by-id path, size, and NUMA
+assignment. As in NVMe mode, the file can be
 reviewed and manually edited before deployment, for example to remove a device from the selection.
 
 ### Partitioned Devices
@@ -88,8 +89,9 @@ sudo {{ cliname }} storage-node deploy --ifname eth0
 ```
 
 Adding the node to the cluster from a control plane node is unchanged as well, with one additional
-flag: if partitioned devices were force-included at configuration time, `--force-format` instructs
-the node addition to wipe partition tables and filesystem signatures (`wipefs`) from those devices:
+flag: if partitioned devices were force-included at configuration time, with `--force-format` the
+node addition is instructed to wipe partition tables and filesystem signatures (`wipefs`) from those
+devices:
 
 ```bash title="Adding the storage node while wiping partitioned devices"
 sudo {{ cliname }} storage-node add-node --force-format <CLUSTER_ID> <NODE_IP>:5000 eth0
@@ -101,7 +103,7 @@ sudo {{ cliname }} storage-node add-node --force-format <CLUSTER_ID> <NODE_IP>:5
 
 During node addition, each selected device is wrapped in an SPDK AIO bdev. No kernel driver unbinding
 takes place — the devices stay visible to the host OS but must not be used by anything else. The
-smallest device becomes the journal device, as in NVMe mode with journal-on-device deployments.
+smallest device is used as the journal device, as in NVMe mode with journal-on-device deployments.
 
 Everything after node addition — cluster activation, pool creation, volume provisioning, and client
 connection — is identical to an NVMe-mode cluster.
@@ -115,5 +117,5 @@ address:
 sudo {{ cliname }} storage-node list-devices <NODE_ID>
 ```
 
-On the host, `lsblk` continues to show the devices, since they remain kernel-owned, and the SPDK
-process exposes one `aio_<serial>` base bdev per device.
+On the host, the devices continue to be shown by `lsblk`, since they remain kernel-owned, and one
+`aio_<serial>` base bdev per device is exposed by the SPDK process.

--- a/docs/non-kubernetes/installation/linux-block-devices.md
+++ b/docs/non-kubernetes/installation/linux-block-devices.md
@@ -49,15 +49,18 @@ Devices can also be selected explicitly, by name or by serial number. The three 
 mutually exclusive:
 
 ```bash title="Selecting block devices by name"
-sudo {{ cliname }} storage-node configure --lblk --blk-names sdb,sdc --max-lvol 50
+sudo {{ cliname }} storage-node configure \
+    --lblk --blk-names sdb,sdc --max-lvol 50
 ```
 
 ```bash title="Selecting all eligible block devices except some"
-sudo {{ cliname }} storage-node configure --lblk --blk-names-exclude sda --max-lvol 50
+sudo {{ cliname }} storage-node configure \
+    --lblk --blk-names-exclude sda --max-lvol 50
 ```
 
 ```bash title="Selecting block devices by serial number or WWN"
-sudo {{ cliname }} storage-node configure --lblk --blk-serials S3EVNX0M602707,S3EVNX0M602708 --max-lvol 50
+sudo {{ cliname }} storage-node configure \
+    --lblk --blk-serials S3EVNX0M602707,S3EVNX0M602708 --max-lvol 50
 ```
 
 A requested device that is busy (mounted, held, or otherwise ineligible) is an error. The
@@ -74,7 +77,8 @@ A device carrying a partition table is not eligible by default. To reuse such a 
 eligible with `--force` at configuration time:
 
 ```bash title="Including a partitioned block device in the selection"
-sudo {{ cliname }} storage-node configure --lblk --blk-names sdb --force --max-lvol 50
+sudo {{ cliname }} storage-node configure \
+    --lblk --blk-names sdb --force --max-lvol 50
 ```
 
 The wipe itself happens later, at node addition, where it has to be requested explicitly with
@@ -94,7 +98,8 @@ additional flag. If partitioned devices were force-included at configuration tim
 (`wipefs`) from those devices:
 
 ```bash title="Adding the storage node while wiping partitioned devices"
-sudo {{ cliname }} storage-node add-node --force-format <CLUSTER_ID> <NODE_IP>:5000 eth0
+sudo {{ cliname }} storage-node add-node \
+    --force-format <CLUSTER_ID> <NODE_IP>:5000 eth0
 ```
 
 !!! danger

--- a/docs/non-kubernetes/operations/lblk-device-operations.md
+++ b/docs/non-kubernetes/operations/lblk-device-operations.md
@@ -37,7 +37,8 @@ time:
 3. Re-run the configuration with a selection that includes the new devices:
 
     ```bash title="Reconfiguring the node with an extended device selection"
-    sudo {{ cliname }} storage-node configure --lblk --blk-names sdb,sdc,sdd --max-lvol 50
+    sudo {{ cliname }} storage-node configure \
+       --lblk --blk-names sdb,sdc,sdd --max-lvol 50
     ```
 
 4. Re-add the node to the cluster. The node joins with the extended device set, and data is

--- a/docs/non-kubernetes/operations/lblk-device-operations.md
+++ b/docs/non-kubernetes/operations/lblk-device-operations.md
@@ -19,8 +19,8 @@ a reboot (for example, `/dev/sdb` and `/dev/sdc` swapping), and the devices are 
 correctly by their persisted serial numbers. The AIO bdevs and the storage stack above them are then
 rebuilt exactly as recorded in the cluster database.
 
-A configured device that is missing from the host at restart is marked removed — the same semantics
-as a missing NVMe controller — and the standard failed-device data migration is triggered.
+A configured device that is missing from the host at restart is marked removed (the same semantics
+as a missing NVMe controller), and the standard failed-device data migration is triggered.
 
 !!! info
     The `--ssd-pcie` option of `storage-node restart`, by which new devices are added during a
@@ -49,17 +49,17 @@ Cluster capacity can alternatively be extended by
 ## Failed Devices
 
 Device failures are handled by the same machinery as in NVMe mode. A device producing IO errors is
-marked unavailable and, after the retry budget is exhausted, marked failed; the cluster map is
+marked unavailable and, after the retry budget is exhausted, marked failed. The cluster map is
 updated, and the affected data is rebuilt from redundancy by a data migration. A device whose IO
-hangs without erroring is caught by the `lblk` hung-IO watchdog — roughly 30 seconds of zero progress with
-outstanding IO — and driven through the same unavailable, restart, and failed path. A device that
+hangs without erroring is caught by the `lblk` hung-IO watchdog (roughly 30 seconds of zero progress
+with outstanding IO) and driven through the same unavailable, restart, and failed path. A device that
 disappears from the host, through hot removal or a cloud volume detach, is detected and treated like
 an NVMe hot-remove.
 
 To replace a failed device, a replacement device is attached to the host, followed by the
-[Adding Devices](#adding-devices-to-a-storage-node) procedure — or the whole node is replaced,
-following [Replacing a Storage Node](replacing-storage-node.md).
+[Adding Devices](#adding-devices-to-a-storage-node) procedure. Alternatively, the whole node is
+replaced, following [Replacing a Storage Node](replacing-storage-node.md).
 
 !!! info
-    SMART health information is not available for AIO-backed devices; device health checks
+    SMART health information is not available for AIO-backed devices. Device health checks
     (`storage-node check-device`) are limited to liveness and IO statistics.

--- a/docs/non-kubernetes/operations/lblk-device-operations.md
+++ b/docs/non-kubernetes/operations/lblk-device-operations.md
@@ -6,25 +6,25 @@ weight: 20090
 
 {{ experimental }}
 
-This page covers day-2 operations specific to clusters in the Linux block device mode (`lblk`).
+Day-2 operations specific to clusters in the Linux block device mode (`lblk`) are described below.
 Concepts and deployment are described under
 [Linux Block Devices (lblk)](../../architecture/concepts/linux-block-devices.md) and
 [Deploy with Linux Block Devices](../installation/linux-block-devices.md).
 
 ## Node Restarts
 
-A node restart requires no lblk-specific handling. On restart, the node's configured devices are
+No `lblk`-specific handling is required for a node restart. On restart, the node's configured devices are
 re-resolved serial-first against the live host inventory: kernel device names may have changed across
 a reboot (for example, `/dev/sdb` and `/dev/sdc` swapping), and the devices are still matched
 correctly by their persisted serial numbers. The AIO bdevs and the storage stack above them are then
 rebuilt exactly as recorded in the cluster database.
 
 A configured device that is missing from the host at restart is marked removed — the same semantics
-as a missing NVMe controller — and triggers the standard failed-device data migration.
+as a missing NVMe controller — and the standard failed-device data migration is triggered.
 
 !!! info
-    The `--ssd-pcie` option of `storage-node restart`, which adds new devices during a restart, is
-    not supported on lblk-mode clusters and is rejected.
+    The `--ssd-pcie` option of `storage-node restart`, by which new devices are added during a
+    restart, is not supported on `lblk`-mode clusters and is rejected.
 
 ## Adding Devices to a Storage Node
 
@@ -40,8 +40,8 @@ time:
     sudo {{ cliname }} storage-node configure --lblk --blk-names sdb,sdc,sdd --max-lvol 50
     ```
 
-4. Re-add the node to the cluster. The node joins with the extended device set, and the automatic
-   rebalancing redistributes data onto it.
+4. Re-add the node to the cluster. The node joins with the extended device set, and data is
+   redistributed onto it by the automatic rebalancing.
 
 Cluster capacity can alternatively be extended by
 [adding a new storage node](scaling/index.md) with its own devices.
@@ -50,8 +50,8 @@ Cluster capacity can alternatively be extended by
 
 Device failures are handled by the same machinery as in NVMe mode. A device producing IO errors is
 marked unavailable and, after the retry budget is exhausted, marked failed; the cluster map is
-updated, and a data migration rebuilds the affected data from redundancy. A device whose IO hangs
-without erroring is caught by the lblk hung-IO watchdog — roughly 30 seconds of zero progress with
+updated, and the affected data is rebuilt from redundancy by a data migration. A device whose IO
+hangs without erroring is caught by the `lblk` hung-IO watchdog — roughly 30 seconds of zero progress with
 outstanding IO — and driven through the same unavailable, restart, and failed path. A device that
 disappears from the host, through hot removal or a cloud volume detach, is detected and treated like
 an NVMe hot-remove.
@@ -62,4 +62,4 @@ following [Replacing a Storage Node](replacing-storage-node.md).
 
 !!! info
     SMART health information is not available for AIO-backed devices; device health checks
-    (`storage-node check-device`) operate on liveness and IO statistics only.
+    (`storage-node check-device`) are limited to liveness and IO statistics.

--- a/docs/non-kubernetes/operations/lblk-device-operations.md
+++ b/docs/non-kubernetes/operations/lblk-device-operations.md
@@ -13,10 +13,10 @@ Concepts and deployment are described under
 
 ## Node Restarts
 
-No `lblk`-specific handling is required for a node restart. On restart, the node's configured devices are
-re-resolved serial-first against the live host inventory: kernel device names may have changed across
-a reboot (for example, `/dev/sdb` and `/dev/sdc` swapping), and the devices are still matched
-correctly by their persisted serial numbers. The AIO bdevs and the storage stack above them are then
+No `lblk`-specific handling is required for a node restart. On restart, the node's configured devices
+are re-resolved serial-first against the live host inventory. Kernel device names may have changed
+across a reboot (for example, `/dev/sdb` and `/dev/sdc` swapping), but the devices are still matched
+correctly by their persisted serial numbers, and the AIO bdevs and the storage stack above them are
 rebuilt exactly as recorded in the cluster database.
 
 A configured device that is missing from the host at restart is marked removed (the same semantics
@@ -50,13 +50,14 @@ Cluster capacity can alternatively be extended by
 
 Device failures are handled by the same machinery as in NVMe mode. A device producing IO errors is
 marked unavailable and, after the retry budget is exhausted, marked failed. The cluster map is
-updated, and the affected data is rebuilt from redundancy by a data migration. A device whose IO
-hangs without erroring is caught by the `lblk` hung-IO watchdog (roughly 30 seconds of zero progress
-with outstanding IO) and driven through the same unavailable, restart, and failed path. A device that
-disappears from the host, through hot removal or a cloud volume detach, is detected and treated like
-an NVMe hot-remove.
+updated, and the affected data is rebuilt from redundancy by a data migration.
 
-To replace a failed device, a replacement device is attached to the host, followed by the
+A device whose IO hangs without erroring is caught by the `lblk` hung-IO watchdog (roughly 30 seconds
+of zero progress with outstanding IO) and driven through the same unavailable, restart, and failed
+path. A device that disappears from the host, through hot removal or a cloud volume detach, is
+detected and treated like an NVMe hot-remove.
+
+A failed device is replaced by attaching a replacement device to the host and then following the
 [Adding Devices](#adding-devices-to-a-storage-node) procedure. Alternatively, the whole node is
 replaced, following [Replacing a Storage Node](replacing-storage-node.md).
 

--- a/docs/non-kubernetes/operations/lblk-device-operations.md
+++ b/docs/non-kubernetes/operations/lblk-device-operations.md
@@ -1,0 +1,65 @@
+---
+title: "Linux Block Device Operations"
+description: "Operating lblk-mode clusters: node restarts with serial-based device resolution, adding block devices to a node, and handling failed devices."
+weight: 20090
+---
+
+{{ experimental }}
+
+This page covers day-2 operations specific to clusters in the Linux block device mode (`lblk`).
+Concepts and deployment are described under
+[Linux Block Devices (lblk)](../../architecture/concepts/linux-block-devices.md) and
+[Deploy with Linux Block Devices](../installation/linux-block-devices.md).
+
+## Node Restarts
+
+A node restart requires no lblk-specific handling. On restart, the node's configured devices are
+re-resolved serial-first against the live host inventory: kernel device names may have changed across
+a reboot (for example, `/dev/sdb` and `/dev/sdc` swapping), and the devices are still matched
+correctly by their persisted serial numbers. The AIO bdevs and the storage stack above them are then
+rebuilt exactly as recorded in the cluster database.
+
+A configured device that is missing from the host at restart is marked removed — the same semantics
+as a missing NVMe controller — and triggers the standard failed-device data migration.
+
+!!! info
+    The `--ssd-pcie` option of `storage-node restart`, which adds new devices during a restart, is
+    not supported on lblk-mode clusters and is rejected.
+
+## Adding Devices to a Storage Node
+
+Growing a node's device set is performed by reconfiguring and re-adding the node, not at restart
+time:
+
+1. Attach the new block devices to the host.
+2. Remove the storage node from the cluster. Its data is migrated to the remaining nodes, as with any
+   [node replacement](replacing-storage-node.md).
+3. Re-run the configuration with a selection that includes the new devices:
+
+    ```bash title="Reconfiguring the node with an extended device selection"
+    sudo {{ cliname }} storage-node configure --lblk --blk-names sdb,sdc,sdd --max-lvol 50
+    ```
+
+4. Re-add the node to the cluster. The node joins with the extended device set, and the automatic
+   rebalancing redistributes data onto it.
+
+Cluster capacity can alternatively be extended by
+[adding a new storage node](scaling/index.md) with its own devices.
+
+## Failed Devices
+
+Device failures are handled by the same machinery as in NVMe mode. A device producing IO errors is
+marked unavailable and, after the retry budget is exhausted, marked failed; the cluster map is
+updated, and a data migration rebuilds the affected data from redundancy. A device whose IO hangs
+without erroring is caught by the lblk hung-IO watchdog — roughly 30 seconds of zero progress with
+outstanding IO — and driven through the same unavailable, restart, and failed path. A device that
+disappears from the host, through hot removal or a cloud volume detach, is detected and treated like
+an NVMe hot-remove.
+
+To replace a failed device, a replacement device is attached to the host, followed by the
+[Adding Devices](#adding-devices-to-a-storage-node) procedure — or the whole node is replaced,
+following [Replacing a Storage Node](replacing-storage-node.md).
+
+!!! info
+    SMART health information is not available for AIO-backed devices; device health checks
+    (`storage-node check-device`) operate on liveness and IO statistics only.


### PR DESCRIPTION
Documents the new **experimental** cluster-global `lblk` device mode (arbitrary Linux block devices — SAS/SATA, virtio, cloud volumes — via SPDK AIO bdevs), implemented on sbcli `md-journal`.

Three pages, all carrying the experimental chip:

- **Architecture › Concepts › Linux Block Devices**: device modes (`nvme`/`lblk`), eligibility rules, serial-first device identity, failure-detection parity (IO errors, control-plane hung-IO watchdog, disappearance sweep), restrictions (cluster-global/deploy-time, journal-on-device only, no SMART).
- **Deployments › Install on Linux › Deploy with Linux Block Devices**: `cluster create --device-mode lblk`, `storage-node configure --lblk` with `--blk-names` / `--blk-names-exclude` / `--blk-serials` selectors, partitioned-device handling (`--force` at configure, `--force-format` at add-node), verification.
- **Maintenance & Operations › Linux Block Device Operations**: restart semantics (serial re-resolution, missing → removed), adding devices via reconfigure + re-add (`--ssd-pcie` rejected on lblk), failed/hung/removed device handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
